### PR TITLE
Toggle webhook stack name based on env

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -46,7 +46,6 @@ if (stackType === 'service') {
 
   const sourceWatcherStackName = getRequiredContext(app.node, 'sourceWatcher:stackName')
   const sourceWatcher = new SourceWatcherStack(app, sourceWatcherStackName, {
-    webhookResourceStackName: getRequiredContext(app.node, 'sourceWatcher:webhookResourceStackName'),
     infraRepoOwner,
     infraRepoName,
     infraSourceBranch,

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -5,7 +5,8 @@
       "region": "us-east-1",
       "createDns": true,
       "domainStackName": "libraries-domain",
-      "slackNotifyStackName": "slack-cd-approvals-test-notifier"
+      "slackNotifyStackName": "slack-cd-approvals-test-notifier",
+      "webhookResourceStackName": "github-webhook-custom-resource-dev"
     },
     "prod": {
       "account": "230391840102",
@@ -13,7 +14,8 @@
       "createDns": false,
       "domainStackName": "library-domain",
       "slackNotifyStackName": "slack-approval-bot-wse-approvals-notifier",
-      "notificationReceivers": "wse-notifications-group@nd.edu"
+      "notificationReceivers": "wse-notifications-group@nd.edu",
+      "webhookResourceStackName": "github-webhook-custom-resource-prod"
     }
   },
 
@@ -30,6 +32,5 @@
   "infraSourceBranch": "main",
   "smokeTestsPath": "test/newman/smoke_tests.postman_collection.json",
 
-  "sourceWatcher:stackName": "static-host-source-watcher",
-  "sourceWatcher:webhookResourceStackName": "github-webhook-custom-resource-dev"
+  "sourceWatcher:stackName": "static-host-source-watcher"
 }

--- a/lib/context-env.ts
+++ b/lib/context-env.ts
@@ -9,6 +9,7 @@ export interface IContextEnv {
   readonly domainStackName?: string
   readonly slackNotifyStackName?: string
   readonly notificationReceivers?: string
+  readonly webhookResourceStackName: string
 }
 
 export class ContextEnv implements IContextEnv {
@@ -18,6 +19,7 @@ export class ContextEnv implements IContextEnv {
   public readonly domainStackName?: string
   public readonly slackNotifyStackName?: string
   public readonly notificationReceivers?: string
+  public readonly webhookResourceStackName: string
 
   public static fromContext = (node: ConstructNode, name: string): IContextEnv => {
     const contextEnv = getRequiredContext(node, 'environments')[name]


### PR DESCRIPTION
The context had hardcoded a value which pointed to a dev stack. This meant to deploy to libnd, one would have to override `sourceWatcher:webhookResourceStackName`.

This change makes the context value part of the env, so the defaults should generally match the appropriate stack in the targeted account.