### PR TITLE
Refactor contextEnv so it can be overridden.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Infrastructure for deploying static websites in a repeatable fashion to be hoste
 
 ### Pipeline
 ```
-cdk deploy -c env=<dev|prod> -c project=<projectName> -c stackType=pipeline -c slackNotifyStackName=[stackName] --all
+cdk deploy -c env=<dev|prod> -c project=<projectName> -c stackType=pipeline -c environments:<div|prod>:slackNotifyStackName=[stackName] --all
 ```
 
 ### Service Stack

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -57,7 +57,7 @@ if (stackType === 'service') {
   const pipeline = new StaticHostPipelineStack(app, pipelineName, {
     projectEnv,
     projectName: projectKey,
-    contextEnvName: envName,
+    contextEnv,
     contact: getRequiredContext(app.node, 'contact'),
     owner: getRequiredContext(app.node, 'owner'),
     gitTokenPath,
@@ -65,7 +65,6 @@ if (stackType === 'service') {
     infraRepoName,
     infraSourceBranch,
     smokeTestsPath: getRequiredContext(app.node, 'smokeTestsPath'),
-    ...contextEnv,
   })
   // Ensure that we always have a source watcher for continuously delivery on the pipeline
   pipeline.addDependency(sourceWatcher)

--- a/lib/config/projects/fatherTed.ts
+++ b/lib/config/projects/fatherTed.ts
@@ -2,7 +2,7 @@ import { OverrideStages } from '../constants'
 import { IProjectDefaults } from '../index'
 
 export const Config: IProjectDefaults = {
-  stackNamePrefix: 'father-ted-archive',
+  stackNamePrefix: 'hesburgh-portal',
   hostnamePrefix: 'hesburghportal',
   domainOverride: {
     domainName: 'nd.edu',

--- a/lib/context-env.ts
+++ b/lib/context-env.ts
@@ -26,13 +26,17 @@ export class ContextEnv implements IContextEnv {
     if (contextEnv === undefined || contextEnv === null) {
       throw new Error(`Context key 'environments.${name}' is required.`)
     }
+    /* eslint-disable max-len */
     return {
+      ...contextEnv,
       name: name,
       env: { account: contextEnv.account, region: contextEnv.region, name: contextEnv.name },
-      createDns: contextEnv.createDns || false,
-      // This should only include optional values
-      ...contextEnv,
+      createDns: node.tryGetContext(`environments:${name}:createDns`) || contextEnv.createDns || false,
+      domainStackName: node.tryGetContext(`environments:${name}:domainStackName`) || contextEnv.domainStackName,
+      slackNotifyStackName: node.tryGetContext(`environments:${name}:slackNotifyStackName`) || contextEnv.slackNotifyStackName,
+      webhookResourceStackName: node.tryGetContext(`environments:${name}:webhookResourceStackName`) || contextEnv.webhookResourceStackName,
     }
+    /* eslint-enable max-len */
   }
 }
 

--- a/lib/static-host-build-role.ts
+++ b/lib/static-host-build-role.ts
@@ -4,6 +4,7 @@ import * as cdk from '@aws-cdk/core'
 
 export interface IStaticHostBuildRoleProps extends RoleProps {
   readonly stackNamePrefix: string
+  readonly hostnamePrefix?: string
   readonly stages: string[]
   readonly artifactBucket: Bucket
   readonly createDns: boolean
@@ -100,9 +101,10 @@ export class StaticHostBuildRole extends Role {
       }),
     )
     // Allow creating and managing s3 bucket for site
+    const prefix = (props.hostnamePrefix || props.stackNamePrefix).substring(0, 25)
     this.addToPolicy(
       new PolicyStatement({
-        resources: serviceStacks.map((stackName) => cdk.Fn.sub('arn:aws:s3:::' + stackName + '*')),
+        resources: [cdk.Fn.sub('arn:aws:s3:${AWS::Region}:${AWS::AccountId}:' + prefix + '*')],
         actions: [
           's3:CreateBucket',
           's3:ListBucket*',

--- a/lib/static-host-pipeline.ts
+++ b/lib/static-host-pipeline.ts
@@ -62,6 +62,7 @@ export class StaticHostPipelineStack extends cdk.Stack {
     const codebuildRole = new StaticHostBuildRole(this, 'CodeBuildTrustRole', {
       assumedBy: new ServicePrincipal('codebuild.amazonaws.com'),
       stackNamePrefix: props.projectEnv.stackNamePrefix,
+      hostnamePrefix: props.projectEnv.hostnamePrefix,
       stages,
       artifactBucket,
       createDns: props.contextEnv.createDns,


### PR DESCRIPTION
In general, context can be overridden with the CLI. But that only works with a flat structure, so the way the "environments" object is structured is problematic. This change will allow overriding with a syntax like:
```
-c environments:prod:webhookResourceStackName='my-stack-name'
```