### PR TITLE
add archives-retention project

### DIFF
--- a/lib/config/projects/archivesRetention.ts
+++ b/lib/config/projects/archivesRetention.ts
@@ -1,0 +1,20 @@
+import { IProjectDefaults } from '../index'
+
+export const Config: IProjectDefaults = {
+  stackNamePrefix: 'archives-retention',
+  appRepoOwner: 'ndlib',
+  appRepoName: 'archives-rr',
+  appSourceBranch: 'master',
+  createWebhook: true,
+  createSpaRedirects: true,
+  supportHtmlIncludes: false,
+  buildOutputDir: 'build',
+  buildScripts: [
+    'scripts/codebuild/install.sh',
+    'scripts/codebuild/pre_build.sh',
+    'scripts/codebuild/build.sh',
+    'scripts/codebuild/post_build.sh',
+  ],
+}
+
+export default Config

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@aws-cdk/aws-ssm": "1.114.0",
     "@aws-cdk/core": "1.114.0",
     "@aws-cdk/custom-resources": "1.114.0",
-    "@ndlib/ndlib-cdk": "1.9.3",
+    "@ndlib/ndlib-cdk": "1.10.2",
     "source-map-support": "^0.5.16"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,10 +1234,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@ndlib/ndlib-cdk@1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@ndlib/ndlib-cdk/-/ndlib-cdk-1.9.3.tgz#da0e6b1b66dcf24706250d3c785537d843116368"
-  integrity sha512-lGJRhn7JPqIgAxzI6JEICv31DvfSGvptj41NDeGoFGP9PlJGBsYrPTD1ZmUKPrioEOoaDXTZEBkDCTOHOmty4A==
+"@ndlib/ndlib-cdk@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@ndlib/ndlib-cdk/-/ndlib-cdk-1.10.2.tgz#9988a458d75fbcdd87f15a3e94db1817576f2a17"
+  integrity sha512-pa4PpGpOyt385A39oArHF/Ecbti3w4otCqII7O3cqdh4xvMV1Nmksyc2TxoHBXDO7A7V3rr5JSLn34LbvkaW2A==
   dependencies:
     "@aws-cdk/aws-apigateway" "^1.91.0"
     "@aws-cdk/aws-cloudformation" "^1.91.0"


### PR DESCRIPTION
The blueprints for this service are quite dated. This brings it in-line with current standards (cdk, up-to-date runtimes, etc.) and condenses its footprint by using shared code.

If/when this is deployed to libnd, [ndlib/archives-rr-blueprints](https://github.com/ndlib/archives-rr-blueprints) could then be deprecated.