### PR TITLE
Fix pipeline for archives retention deployment

### DIFF
--- a/lib/config/projects/archivesRetention.ts
+++ b/lib/config/projects/archivesRetention.ts
@@ -1,4 +1,6 @@
 import { IProjectDefaults } from '../index'
+import { PolicyStatement } from '@aws-cdk/aws-iam'
+import { Fn } from '@aws-cdk/core'
 
 export const Config: IProjectDefaults = {
   stackNamePrefix: 'archives-retention',
@@ -14,6 +16,18 @@ export const Config: IProjectDefaults = {
     'scripts/codebuild/pre_build.sh',
     'scripts/codebuild/build.sh',
     'scripts/codebuild/post_build.sh',
+  ],
+  deploymentPolicies: [
+    new PolicyStatement({
+      resources: [
+        Fn.sub('arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/all/contentful/*'),
+      ],
+      actions: [
+        'secretsmanager:DescribeSecret',
+        'secretsmanager:GetSecretValue',
+        'secretsmanager:ListSecretVersionIds',
+      ],
+    }),
   ],
 }
 

--- a/lib/static-host-build-project.ts
+++ b/lib/static-host-build-project.ts
@@ -112,6 +112,7 @@ export default class StaticHostBuildProject extends PipelineProject {
                 ${additionalContext.join(' ')} \
                 --require-approval=never
               `,
+              'cd -',
             ],
           },
           // Now build the actual application (if applicable)


### PR DESCRIPTION
As it turns out, codebuild maintains the working directory between pre_build and build steps. Thus, we want to return to the app directory after setting up the infrastructure so it can run the build scripts in the app repo.

The other bit is a specific secret that archives-retention retrieves during the build script, so the codebuild needs permission to fetch that.